### PR TITLE
Update breakpoints setting in manifest

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -24,15 +24,15 @@
     },
     "devDependencies": {},
     "contributes": {
+        "breakpoints": [
+            {
+                "language": "lua"
+            }
+        ],
         "debuggers": [
             {
                 "type": "lua",
                 "label": "Lua Debugger",
-                "enableBreakpointsFor": {
-                    "languageIds": [
-                        "lua"
-                    ]
-                },
                 "program": "./DebugAdapter.exe",
                 "osx": {
                     "runtime": "mono"


### PR DESCRIPTION
`contributes.debuggers.enableBreakpointsFor` is no longer supported in the package manifest. The replacement is `contributes.breakpoints`. 

See https://github.com/xdebug/vscode-php-debug/issues/424#issue-740848506, for more info.

Without this change, VS Code won't set breakpoints. 